### PR TITLE
Add python-novaclient version constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setuptools.setup(
                 'extensions',
     license='Apache License, Version 2.0',
     url='https://github.com/rackerlabs/rackspace-novaclient',
-    install_requires=['python-novaclient'] + novaclient_extensions,
+    install_requires=[
+        'python-novaclient>=2.35.0,<3'
+    ] + novaclient_extensions,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
As per #16 and #17 newer versions of `python-novaclient` have proven incompatible with `rackspace-novaclient`.

Whichever codebase needs work to fix these compatibility issues it is important that `rackspace-novaclient` continue to install in a working state until they are resolved.

This PR introduces a [semantic version](http://semver.org/) limit to the `python-novaclient` dependency which:

* ensures a minimum version of `2.35.0` - the current highest "known good" version.
* ensures a maximum version of `3.x` - as per semver rules a major version increment may containing backwards-incompatible changes and seems to do so in this case.

Fixes #16, fixes #17.