### PR TITLE
Put back os_virtual_interfacesv2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ novaclient_extensions = [
                                                         #   backup_schedule)
 
     'os_networksv2_python_novaclient_ext',              # Rax_Networks
-    # 'os_virtual_interfacesv2_python_novaclient_ext',    # Virtual interfaces
+    'os_virtual_interfacesv2_python_novaclient_ext',    # Virtual interfaces
     'rax_default_network_flags_python_novaclient_ext',  # default network flags
     'ip_associations_python_novaclient_ext',            # ip associations
 ]


### PR DESCRIPTION
Master branch of o_v_iv2 seems to work with latest novaclient just fine.
roaet is releasing it today; put it back in this package.

NOTE: don't release until 0.20 exists here: https://pypi.python.org/pypi/os_virtual_interfacesv2_python_novaclient_ext